### PR TITLE
FIX pango markup escape & updated deprecated option

### DIFF
--- a/tinyfiledialogs.c
+++ b/tinyfiledialogs.c
@@ -4435,13 +4435,13 @@ int tinyfd_messageBox(
 
                 if (strcmp("yesnocancel", aDialogType)) strcat(lDialogString, " --no-wrap");
 
-                strcat(lDialogString, " --text=\"") ;
+                strcat(lDialogString, " --no-markup --text=\"") ;
                 if (aMessage && strlen(aMessage)) strcat(lDialogString, aMessage) ;
                 strcat(lDialogString, "\"") ;
 
                 if ( (tfd_zenity3Present() >= 3) || (!tfd_zenityPresent() && (tfd_shellementaryPresent() || tfd_qarmaPresent()) ) )
                 {
-                        strcat( lDialogString , " --icon-name=dialog-" ) ;
+                        strcat( lDialogString , " --icon=dialog-" ) ;
                         if ( aIconType && (! strcmp( "question" , aIconType )
                           || ! strcmp( "error" , aIconType )
                           || ! strcmp( "warning" , aIconType ) ) )


### PR DESCRIPTION
Pango markup extends the plain text capabilities of GTK. However, when used in a simple message box, this option may not be desirable. To escape Pango markup,
the --no-markup option should be used.

Without the --no-markup option, strings like the following will not render as intended:

```sh
~ $ zenity --error --text="<info></info>"

(zenity:289545): Gtk-WARNING **: 21:49:47.869: Failed to set text '<info></info>' from markup due to error parsing markup: Unknown tag 'info' on line 1 char 23
TU: error: ../src/freedreno/vulkan/tu_knl.cc:352: failed to open device /dev/dri/renderD129 (VK_ERROR_INCOMPATIBLE_DRIVER)
```

Whereas

```sh
~ $ zenity --error --no-markup --text="<info></info>"
```

--icon-name is deprecated
```
~ $ zenity --info "hello" --icon-name="warn"
Warning: --icon-name is deprecated and will be removed in a future version of zenity; Treating as --icon.
```